### PR TITLE
[DM-35642] Move history and decisions elsewhere

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -5,10 +5,12 @@
 Abstract
 ========
 
-Rubin Observatory plans to use COmanage as the identity management platform for the Rubin Science Platform.
-Group membership will be maintained inside COmanage.
-UID and GID assignment will be done outside of COmanage by Gafaelfawr_, the authentication and authorization component of the Rubin Science Platform.
-This tech note provides a step-by-step how to configure COmanage for that purpose, discusses alternate configuration approaches that were discarded, discusses integration requirements, and summarizes remaining COmanage work.
+COmanage_ is a user management system designed for academic and research collaborations.
+Rubin Observatory will use COmanage (as provided by CILogon_) as the user identity store and group management system for the Rubin Science Platform.
+This tech note provides the specific details of the COmanage configuration used by the Science Platform and summarizes remaining COmanage work.
+
+.. _COmanage: https://www.incommon.org/software/comanage/
+.. _CILogon: https://cilogon.org/
 
 .. note::
 
@@ -19,32 +21,6 @@ This tech note provides a step-by-step how to configure COmanage for that purpos
 .. _DMTN-234: https://dmtn-234.lsst.io/
 .. _DMTN-224: https://dmtn-224.lsst.io/
 .. _SQR-069: https://sqr-069.lsst.io/
-
-Decisions
-=========
-
-#. **Use COmanage for group management.**
-   Grouper offers more features, but at the cost of additional user complexity, a UI that's not better than the COmanage UI, a less usable API, and additional integration and conceptual complexity.
-   We will need to add a plugin to do group name validation (see :ref:`Group name validation <group-name-validation>`).
-
-#. **Assign UIDs and GIDs outside of COmanage.**
-   It's possible to manage both inside COmanage, using ``voPosixGroup`` to do GID assignment and an auto-incrementing unique ID to do UID assignment (as a string that would require some postprocessing).
-   However, this doesn't let us enforce range boundaries or use a different range for bot users.
-   We will instead use Google Firestore to store UIDs and GIDs.
-
-#. **Use LDAP as the primary API to retrieve user and group data.**
-   Despite requiring an LDAP library dependency, this looks easier to use than the COmanage or Grouper APIs.
-
-#. **Implement quota rules outside of COmanage.**
-   We have to maintain a local database anyway for the token system and can put quota metadata in the same place.
-   Neither COmanage nor Grouper easily support quota math.
-   The Grouper API could allow us to use it as a backing store for quota data, but the API is sufficiently hard to use that this isn't an attractive option.
-
-#. **Manage user metadata in Gafaelfawr.**
-   Gafaelfawr_ will gather data from LDAP on demand, with a local cache to reduce the LDAP load, and merge that with data stored with the token.
-   This can be extended to support quotas when those are added.
-
-.. _Gafaelfawr: https://gafaelfawr.lsst.io/
 
 Configuration
 =============
@@ -213,150 +189,6 @@ This plugin does not already exist, but the CILogon folks have a previously-writ
 
 .. _CakePHP Event System: https://book.cakephp.org/2/en/core-libraries/events.html
 
-Dashboard
----------
-
-COmanage comes with a bunch of default components that we don't want to use (announcement feeds, forums, etc.).
-We will want to edit the default dashboard to remove those widges and replace them with widges for group management and personal identity management (if there are any applicable ones).
-
-Other configurations considered
-===============================
-
-Group management
-----------------
-
-We have two primary options for managing groups via COmanage: using COmanage Registry groups, or using Grouper.
-In both cases, there are limitations on how much we can customize the UI without a lot of development.
-
-Quota calculation is not directly supported with either system and in either case would need custom development (either via a plugin or via a service that used the group API).
-Recording quota information for groups locally and using the group API (or LDAP) to synchronize the list of groups with the canonical list looks like the easiest path.
-
-COmanage Registry groups
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Advantages:
-
-.. rst-class:: compact
-
-#. Uses the same UI as the onboarding and identity management process
-#. Possible (albeit complex) to automatically generate GIDs using ``voPosixGroup`` (see :ref:`voPosixGroup <voposixgroup>`)
-
-Disadvantages:
-
-.. rst-class:: compact
-
-#. No support for nested groups
-#. Groups cannot own other groups
-#. No support for set math between groups
-#. No generic metadata support, so group quotas would need to be maintained separately (presumably by a Rubin-developed service)
-#. There currently is a rendering bug that causes each person to show up three times when editing the group membership, but this will be fixed in the 4.0.0 release due in the second quarter of 2021
-
-Grouper
-^^^^^^^
-
-Advantages:
-
-.. rst-class:: compact
-
-#. Full support for nested groups
-#. Groups can own other groups
-#. Specializes in set math between groups if we want to do complex authorization calculations
-#. Arbitrary metadata can be added to groups via the API, so we could use Grouper as our data store rather than a local database
-
-Disadvantages:
-
-.. rst-class:: compact
-
-#. More complex setup and data flow
-#. Users have to interact with two UIs, the COmanage one for identities and the Grouper UI for group management
-#. No support for automatic GID generation
-
-.. _gid:
-
-Numeric GIDs
-------------
-
-Getting numeric GIDs into the LDAP entries for each group isn't well-supported by COmanage.
-The LDAP connector does not have an option to add arbitrary group identifiers to the group LDAP entry.
-
-We decided to avoid this problem by assigning UIDs and GIDs outside of COmanage.
-Here are a few other possible options we considered.
-
-COmanage group REST API
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Arbitrary identifiers can be added to groups, so a group can be configured with an auto-incrementing unique identifier in the same way that we do for users, using a base number of 200000 instead of 100000 to keep the UIDs and GIDs distinct (allowing the UID to be used as the GID of the primary group).
-Although that identifier isn't exposed in LDAP, it can be read via the COmanage REST API using a URL such as::
-
-    https://<registry-url>/registry/identifiers.json?cogroupid=7
-
-The group ID can be obtained from the ``/registry/co_groups.json`` route, searching on a specific ``coid``.
-Middleware running on the Rubin Science Platform could cache the GID information for every group, refresh it periodically, and query for the GID of a new group when seen.
-
-.. _voposixgroup:
-
-voPosixGroup
-^^^^^^^^^^^^
-
-Another option is to enable ``voPosixGroup`` and generate group IDs that way.
-However, that process is somewhat complex.
-
-COmanage Registry has the generic notion of a `Cluster <https://spaces.at.internet2.edu/display/COmanage/Clusters>`__.
-A Cluster is used to represent a CO Person's accounts with a given application or service.
-
-Cluster functionality is implemented by Cluster Plugins.
-Right now there is one Cluster Plugin that comes out of the box with COmanage, the `UnixCluster plugin <https://spaces.at.internet2.edu/display/COmanage/Unix+Cluster+Plugin>`__.
-
-The UnixCluster plugin is configured with a "GID Type."
-From the documentation: "When a CO Group is mapped to a Unix Cluster Group, the CO Group Identifier of this type will be used as the group's numeric ID."
-CO Person can then have a UnixCluster account that has associated with it a UnixCluster Group, and the group will have a GID identifier.
-
-To have the information about the UnixCluster and the UnixCluster Group provisioned into LDAP using the ``voPosixAccount`` objectClass, define a `CO Service <https://spaces.at.internet2.edu/display/COmanage/Registry+Services>`__ for the UnixCluster.
-In that configuration you need to specify a "short label", which will become value for an LDAP attribute option.
-Since the ``voPosixAccount`` objectClass attributes are multi-valued, you can represent multiple "clusters," and they are distinguised by using that LDAP attribute option value.
-For example::
-
-    dn: voPersonID=LSST100000,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    sn: KORANDA
-    cn: SCOTT KORANDA
-    objectClass: person
-    objectClass: organizationalPerson
-    objectClass: inetOrgPerson
-    objectClass: eduMember
-    objectClass: voPerson
-    objectClass: voPosixAccount
-    givenName: SCOTT
-    mail: SKORANDA@CS.WISC.EDU
-    uid: http://cilogon.org/server/users/2604273
-    isMemberOf: CO:members:all
-    isMemberOf: CO:members:active
-    isMemberOf: scott.koranda UnixCluster Group
-    voPersonID: LSST100000
-    voPosixAccountUidNumber;scope-primary: 1000000
-    voPosixAccountGidNumber;scope-primary: 1000000
-    voPosixAccountHomeDirectory;scope-primary: /home/scott.koranda
-
-This reflects a CO Service for the UnixAccount using the short label "primary."
-With a second UnixCluster and CO Service with short label "slac" to represent an account at SLAC, this record would have additionally::
-
-    voPosixAccountGidNumber;scope-slac: 1000001
-
-The UnixCluster object and UnixCluster Group objects and all the identifiers are usually established during an enrollment flow.
-
-Grouper
-^^^^^^^
-
-Grouper does not have built-in support for assigning numeric GIDs to each group out of some range.
-It is possible to cobble something together using the ``idIndex`` that Grouper generates (see `this discussion <https://lists.internet2.edu/sympa/arc/grouper-users/2017-01/msg00087.html>`__ and `this documentation <https://spaces.at.internet2.edu/display/Grouper/Integer+IDs+on+Grouper+objects>`__), but it would require some development.
-
-Alternately, groups can be assigned arbitrary attributes that we define, so we can assign GIDs to groups via the API, but we would need to maintain the list of available GIDs and ensure there are no conflicts.
-Grouper also does not appear to care if the same attribute value is assigned to multiple groups, so we would need to handle uniqueness.
-
-Custom development
-^^^^^^^^^^^^^^^^^^
-
-We could enhance (or pay someone to enhance) the LDAP Provisioning Plugin to allow us to express an additional object class in the group tree in LDAP, containing a numeric GID identifier.
-
 API
 ===
 
@@ -372,47 +204,7 @@ To make LDAP queries, use commands like:
                 -x -w PASSWORD -b 'ou=people,o=LSST,o=CO,dc=lsst,dc=org'
 
 The password is in 1Password under the hostname of the COmanage registry.
-
-An example user::
-
-    dn: voPersonID=LSST100006,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    displayName: Russ Allbery
-    sn: Allbery
-    cn: Russ Allbery
-    objectClass: person
-    objectClass: organizationalPerson
-    objectClass: inetOrgPerson
-    objectClass: eduMember
-    objectClass: voPerson
-    uid: http://cilogon.org/serverA/users/31388556
-    uid: http://cilogon.org/serverA/users/15423111
-    isMemberOf: CO:members:all
-    isMemberOf: CO:members:active
-    isMemberOf: CO:admins
-    isMemberOf: g_science-platform-idf-dev
-    isMemberOf: g_test-group
-    voPersonApplicationUID: rra
-    voPersonID: LSST100006
-    voPersonSoRID: http://cilogon.org/serverA/users/31388556
-
-An example group::
-
-    dn: cn=g_science-platform-idf-dev,ou=groups,o=LSST,o=CO,dc=lsst,dc=org
-    cn: g_science-platform-idf-dev
-    member: voPersonID=LSST100006,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    member: voPersonID=LSST100007,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    member: voPersonID=LSST100008,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    member: voPersonID=LSST100010,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    member: voPersonID=LSST100012,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    member: voPersonID=LSST100013,ou=people,o=LSST,o=CO,dc=lsst,dc=org
-    objectClass: groupOfNames
-    objectClass: eduMember
-    hasMember: rra
-    hasMember: thoron
-    hasMember: frossie
-    hasMember: cbanek
-    hasMember: afausti
-    hasMember: simonkrughoff
+Use ``ou=people,o=LSST,o=CO,dc=lsst,dc=org`` for people and ``ou=groups,o=LSST,o=CO,dc=lsst,dc=org`` for groups.
 
 COmanage REST API
 -----------------
@@ -422,97 +214,8 @@ The base URL is the hostname of the COmanage registry service with ``/registry``
 
 We currently don't expect to use the REST API.
 
-Grouper REST API
-----------------
-
-Grouper supports a REST API.
-However, it appears to be very complex and documented primarily as a Java API.
-I was unable to locate a traditional REST API description for it.
-The API looks to be fully functional but it makes a number of unusual choices, such as ``T`` and ``F`` strings instead of proper booleans.
-
-Using the API appears to require a lot of reverse engineering from example traces.
-See, for instance, the `example of assigning an attribute value to a group <https://github.com/Internet2/grouper/blob/master/grouper-ws/grouper-ws/doc/samples/assignAttributesWithValue/WsSampleAssignAttributesWithValueRestLite_json.txt>`__.
-
-A sample Grouper API call:
-
-.. code-block:: console
-
-   $ curl --silent -u GrouperSystem:XXXXXXXX \
-     'https://group-registry-test.lsst.codes/grouper-ws/servicesRest/json/v2_5_000/groups/etc%3Asysadmingroup/members' \
-     | jq .
-
-We didn't investigate this further since we decided against using Grouper for group management.
-
-Integration
-===========
-
-On the Rubin Science Platform side, we will need to implement the following.
-
-User information
-----------------
-
-Gafaelfawr_ will be set up to use OpenID Connect for authentication, using the OIDC client information configured above.
-It will take the authenticated username from the ``username`` claim of the token, and then look up other information about the user (group membership, full name, email address) from LDAP on demand with a short-lived cache.
-(UIDs and GIDs will be handled externally from COmanage in Firestore.)
-
-Full name should always be ``displayName`` and we should not use the other LDAP attributes that attempt to parse a name into components.
-They do not internationalize well.
-Unfortunately, the COmanage sign-on flow still asks for users to enter their name in components.
-
-User onboarding API
--------------------
-
-The "Self Signup With Approval" flow seems to be the closest fit for our requirements.
-To initiate that flow, we send the user to a specific URL at the COmanage registry.
-We can initiate that flow from the landing page or from Gafaelfawr if we detect that the user is authenticated but not enrolled in COmanage.
-
-It's possible to then configure a return URL to which the user goes after enrollment is complete, but that's probably not that useful when we're using an approval flow.
-
-We will need to customize the email messages and web pages presented as part of the approval flow.
-This has not yet been done.
-
-It's not clear yet whether we will need to automate additional changes to a person's record after onboarding, such as adding them to groups, or if this will be handled manually during the approval process.
-If we do need to automate this, we may need to do that via the COmanage API.
-
-The web pages shown during this onboarding flow are controlled by the style information in the `lsst-registry-landing <https://github.com/cilogon/lsst-registry-landing>`__ project on GitHub.
-
-Email verification issue
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Currently, user onboarding has a bug: After choosing their name, email, and username, the user is sent an email message to confirm that they have control over that email address.
-The link in the mail message has a one-time code in it, and confirms the email address when followed.
-However, sites with anti-virus integrated with their email system (such as AURA) often pre-fetch all URLs seen in email addresses.
-Since no authentication or confirmation is required when following the link, this means that any email address at such a domain is automatically confirmed without any human interaction, posing both a security flaw and a UI problem because the user will get a confusing error message when they follow that link manually.
-
-We will need to work with the COmanage maintainers to either require authentication to confirm the email address or to require a button that one has to click rather than doing the confirmation automatically.
-
-User authorization
-------------------
-
-COmanage does not preserve the affiliation information sent by the identity provider, if any.
-Affiliation in COmanage must be set to one of a restricted set of values, and the affiliation given by identity providers is free-form.
-In our test instance, the affiliation was forced to always be "affiliate" to avoid this problem.
-
-If we want to make use of the affiliation sent by the upstream identity provider for authorization decisions, we will have to write a COmanage plugin.
-The difficult part of that is defining what the business logic should be.
-
-To see the affiliation attributes sent by an identity provider, go directly to `CILogon <https://cilogon.org/>`__ and log on via that provider.
-On the resulting screen, look at the User Attributes section.
-
-User self groups
-----------------
-
-Each user will appear to the Rubin Science Platform to also be the sole member of a group with the same name as the username and the same GID as the UID.
-This is a requirement for POSIX file systems underlying the Notebook Aspect and for the Butler service (see DMTN-182_ for the latter).
-
-.. _DMTN-182: https://dmtn-182.lsst.io/
-
-These groups will not be managed in COmanage or Grouper.
-They will be synthesized by Gafaelfawr_ in response to queries about the user.
-(This work is not yet done.)
-
-Example Gafaelfawr configuration
---------------------------------
+Gafaelfawr
+==========
 
 Here is an example configuration of the Gafaelfawr Helm chart to use CILogon and COmanage.
 This is suitable for the ``values-*.yaml`` file in Phalanx_.
@@ -543,6 +246,9 @@ This uses the CILogon test LDAP server (a production configuration will probably
 Open COmanage work
 ==================
 
-#. Add a button or require authentication before confirming the email address to avoid a bug in the onboarding flow.
+- Add a button or require authentication before confirming the email address to avoid a bug in the onboarding flow.
 
-#. Write a CakePHP plugin to enforce a group naming convention.
+- Write a CakePHP plugin to enforce a group naming convention.
+
+- COmanage comes with a bunch of default components that we don't want to use (announcement feeds, forums, etc.).
+  Edit the default dashboard to remove those widges and replace them with widges for group management and personal identity management (if there are any applicable ones).

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,7 +34,9 @@ authors:
 # doi: 10.5281/zenodo.#####
 
 # Copyright statement
-copyright: "2021, Association of Universities for Research in Astronomy, Inc. (AURA)"
+copyright: >-
+  2021-2022, Association of Universities for Research in Astronomy,
+  Inc. (AURA)
 
 # Description. A short, 1-2 sentence statemement used by document indices.
 description: >
@@ -43,14 +45,12 @@ description: >
 
 # Abstract, if available
 abstract: >
- Rubin Observatory plans to use COmanage as the identity management platform
- for the Rubin Science Platform.  Group membership will be maintained inside
- COmanage.  UID and GID assignment will be done outside of COmanage by
- Gafaelfawr, the authentication and authorization component of the Rubin
- Science Platform.  This tech note provides a step-by-step how to configure
- COmanage for that purpose, discusses alternate configuration approaches that
- were discarded, discusses integration requirements, and summarizes remaining
- COmanage work.
+  COmanage is a user management system designed for academic and research
+  collaborations.  Rubin Observatory will use COmanage (as provided by
+  CILogon) as the user identity store and group management system for the
+  Rubin Science Platform.  This tech note provides the specific details of the
+  COmanage configuration used by the Science Platform and summarizes remaining
+  COmanage work.
 
 # URL where this document is published by Read the Docs. e.g. http://sqr-001.lsst.codes
 url: "https://sqr-055.lsst.io"


### PR DESCRIPTION
This tech note is now purely the COmanage configuration details,
some supporting information about API and Gafaelfawr configuration,
and necessary work.

The history of decisions and evaluations has been moved to SQR-069.
The details of the integration have been moved to DMTN-224.